### PR TITLE
add demos folder and subfolder for super demo SD416

### DIFF
--- a/demos/SD416-Wujek-AutotuneWebDashboard/README.md
+++ b/demos/SD416-Wujek-AutotuneWebDashboard/README.md
@@ -1,0 +1,3 @@
+The ability to monitor the AUTOTUNE search process and review the quality of candidate models during execution can offer an important balance between automation and the desired (arguably necessary) human oversight. This demo shows you how to use a new live monitoring capability to develop a dashboard for this purpose.
+
+The slides presented in this demo are included here, along with code for the demo.


### PR DESCRIPTION
The demos folder is for (a) super demos, and (b) any other demo material people want to share, possibly from booths in the Quad.
Feel free to suggest different conventions for these.