### PR TITLE
Update sasLogParserMacros.sas

### DIFF
--- a/papers/4147-2020-Sober/sasLogParserMacros.sas
+++ b/papers/4147-2020-Sober/sasLogParserMacros.sas
@@ -8,7 +8,12 @@
     %put Directory &dir cannot be open or does not exist;
     %return;
   %end;
-
+  
+  %if (%upcase(%substr(&SYSSCP, 1, 3)) = WIN) %then
+     %let delm = \;
+  %else
+     %let delm = /; 
+	   	   
    %do i = 1 %to %sysfunc(dnum(&did));   
 
    %let name=%qsysfunc(dread(&did,&i));
@@ -16,8 +21,8 @@
       %if %qupcase(%qscan(&name,-1,.)) = %upcase(&ext) %then %do;
         %put &dir.&name;
       %end;
-      %else %if %qscan(&name,2,.) = %then %do;        
-        %list_files(&dir.&name,&ext)
+      %else %if %qscan(&name,2,.) = %then %do;    
+        %list_files(&dir.&name&delm.,&ext)
       %end;
 
    %end;


### PR DESCRIPTION
Added logic (lines 12-15) based on operating system to set a new macro variable &delm. to / for Linux and \ for Windows.

Modified line 25 to use the new macro variable &delm. which allows the utility to do a recursive parsing of log files in the parent directory as well as all sub-directories.